### PR TITLE
Ignore the '$ref' element

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,10 @@ const rules = sofia(
     $lastDoc: 'resource.data',
     $userId: 'request.auth.uid',
     $offset: 'request.query.offset',
-    ['databases/{database}']: {
+    ['databases/{database}/documents']: {
       // Define the reference of the existing collection. This object effectively
       // describes the database root as 'databases/{database}/documents'.
-      $ref: 'documents',
-      atomic: {
-        $ref: 'docId',
+      ['atomic/docId']: {
         // Here we define the list rule, where we state callers are permitted
         // to make list queries if they have provided a falsey offset. 
         // Looking at the global variables, offset refers to "request.query.offset".

--- a/index.js
+++ b/index.js
@@ -441,10 +441,6 @@ const getVariables = (def) => {
     );
 };
 
-const parseRef = (str) => {
-  return ref;
-};
-
 function rules(def, stack = [], ref, pwd = '', depth = 0, str = '') {
   const $variable = getVariables(
     def,
@@ -466,18 +462,11 @@ function rules(def, stack = [], ref, pwd = '', depth = 0, str = '') {
       (str, [relative, entity]) => {
         const type = typeof entity;
         if (type === 'object') {
-          // XXX: Ensure $refs are visible within the scope of
-          //      declaration.
-          const {
-            $ref,
-          } = entity;
+          const $ref = relative.substring(relative.lastIndexOf('/') + 1, relative.length);
           const redacted = relative.substring(0, relative.lastIndexOf($ref) - 1);
-          console.log('redacted '+redacted+ ' from '+relative+' with ref '+$ref);
           const absolute = `${pwd}/${relative}`;
           const match = `match /${redacted}/${$ref}`;
           const newPwd = `${pwd}/${redacted}`;
-          console.log('match '+match);
-          console.log('new pwd '+newPwd);
           const evaluated = rules(
             entity,
             nextStack,

--- a/index.js
+++ b/index.js
@@ -441,6 +441,10 @@ const getVariables = (def) => {
     );
 };
 
+const parseRef = (str) => {
+  return ref;
+};
+
 function rules(def, stack = [], ref, pwd = '', depth = 0, str = '') {
   const $variable = getVariables(
     def,
@@ -462,19 +466,23 @@ function rules(def, stack = [], ref, pwd = '', depth = 0, str = '') {
       (str, [relative, entity]) => {
         const type = typeof entity;
         if (type === 'object') {
-          const absolute = `${pwd}/${relative}`;
           // XXX: Ensure $refs are visible within the scope of
           //      declaration.
           const {
             $ref,
           } = entity;
-          const scope = deref($ref);
-          const match = `match /${relative}/${scope}`;
+          const redacted = relative.substring(0, relative.lastIndexOf($ref) - 1);
+          console.log('redacted '+redacted+ ' from '+relative+' with ref '+$ref);
+          const absolute = `${pwd}/${relative}`;
+          const match = `match /${redacted}/${$ref}`;
+          const newPwd = `${pwd}/${redacted}`;
+          console.log('match '+match);
+          console.log('new pwd '+newPwd);
           const evaluated = rules(
             entity,
             nextStack,
-            scope,
-            `${pwd}/${relative}`,
+            $ref,
+            `${pwd}/${redacted}`,
             depth + 1,
             '',
           );
@@ -487,7 +495,8 @@ function rules(def, stack = [], ref, pwd = '', depth = 0, str = '') {
       compile(
         def,
         nextStack,
-        deref(ref),
+        // TODO: Used to be deref, but now $refs are required.
+        ref,
         pwd,
         depth,
         str,

--- a/index.test.js
+++ b/index.test.js
@@ -22,30 +22,23 @@ test('that a simple nested collections, references and rulesn can be defined', f
   const rules = sofia(
     {
       ['databases/{database}/documents']: {
-        $ref: 'documents',
         ['example/{document=**}']: {
-          $ref: '{document=**}',
           ['nested/{document=**}']: {
-            $ref: '{document=**}',
             ['collection/{collectionDocId}']: {
-              $ref: '{collectionDocId}',
               $read: false,
               $list: false,
               $create: true,
               $update: true,
             },
             ['someOtherCollection/{someOtherCollectionDocId}']: {
-              $ref: '{someOtherCollectionDocId}',
               $read: false,
               $list: false,
               $create: true,
               $update: true,
               ['someOtherCollectionChildCollection/{document=**}']: {
-                $ref: '{document=**}',
                 $read: false,
                 $write: true,
                 ['someDeeplyNestedCollection/{someDeeplyNestedDocId}']: {
-                  $ref: '{someDeeplyNestedDocId}',
                 },
               },
             },
@@ -90,14 +83,12 @@ test('that we can reference variables that support scope', function() {
   const rules = sofia(
     {
       ['databases/{database}/documents']: {
-        $ref: 'documents',
         // XXX: Global variables across the database documents.
         //      (These can be overwritten by scope.)
         $userId: 'request.auth.uid',
         ['secrets/secretOwnerId']: {
           // XXX: A $ref has the visibility within the collection
           //      as an identifier of the source document.
-          $ref: 'secretOwnerId',
           $read: '$userId != null && $userId === secretOwnerId',
         },
       },
@@ -129,9 +120,7 @@ test('that complex expressions can be defined', function() {
       $userId: 'request.auth.uid',
       $offset: 'request.query.offset',
       ['databases/{database}/documents']: {
-        $ref: 'documents',
         ['atomic/docId']: {
-          $ref: 'docId',
           $list: '$offset == null || $offset == 0',
           $update: [
             ensureNotDeleted('$nextDoc'),
@@ -161,9 +150,7 @@ test('that sofia supports transactions and relative path definitions', function(
     {
       ['databases/{database}/documents']: {
         $userId: 'request.auth.uid',
-        $ref: 'documents',
         ['report/reportId']: {
-          $ref: 'reportId',
           $exists: {
             $flagExists: './../../../databases/{database}/report/$(reportId)/flag/$($userId)',
           },
@@ -172,7 +159,6 @@ test('that sofia supports transactions and relative path definitions', function(
           },
           $create: '!$flagExists && $flagExistsAfter',
           ['flag/flagId']: {
-            $ref: 'flagId',
           },
         },
       },
@@ -196,17 +182,14 @@ test('that variables can reference other variables in the parent scope', functio
   const rules = sofia(
     {
       ['databases/{database}/documents']: {
-        $ref: 'documents',
         $nextDoc: 'request.resource.data',
         $userId: 'request.auth.uid',
         ['outer/{document=**}']: {
-          $ref: '{document=**}',
           $getAfter: {
             $outerVariable: './$($userId)',
           },
           $read: '$outerVariable != null',
           ['inner/innerRefId']: {
-            $ref: 'innerRefId',
             $innerVariable: '$outerVariable.userId',
             $create: '$innerVariable == $userId',
           },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "constants",
     "dynamic"
   ],
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Firestore rules. With variables.",
   "main": "index.js",
   "repository": "https://github.com/Cawfree/sofia",


### PR DESCRIPTION
Document indexing modes now need to be declared as part of the collection key, instead of formally via the $ref.